### PR TITLE
[DEV-3420] Report next line (same column) instead of next node's position

### DIFF
--- a/internal/rule/imports/rule.go
+++ b/internal/rule/imports/rule.go
@@ -103,6 +103,5 @@ func compare(given, expected []importStmt) int {
 }
 
 func report(out io.Writer, i importStmt) {
-	fmt.Fprintf(out, "%s:%d:%d: incorrectly sorted import package: %s\n",
-		i.position.Filename, i.position.Line, i.position.Column, i.pkg)
+	fmt.Fprintf(out, "%s: incorrectly sorted import package: %s\n", i.position, i.pkg)
 }

--- a/internal/rule/imports/rule.go
+++ b/internal/rule/imports/rule.go
@@ -37,14 +37,8 @@ func processImports(f *ast.File, fset *token.FileSet, out io.Writer) {
 }
 
 type importStmt struct {
-	pkg string
-	loc location
-}
-
-type location struct {
-	filename string
-	line     int
-	col      int
+	pkg      string
+	position token.Position
 }
 
 func parse(f *ast.File, fset *token.FileSet) []importStmt {
@@ -52,14 +46,10 @@ func parse(f *ast.File, fset *token.FileSet) []importStmt {
 
 	for _, i := range f.Imports {
 		pos := i.Path.ValuePos
-		loc := location{
-			filename: fset.Position(pos).Filename,
-			line:     fset.Position(pos).Line,
-			col:      fset.Position(pos).Column,
-		}
+		position := fset.Position(pos)
 		imports = append(imports, importStmt{
-			pkg: strings.Trim(i.Path.Value, `"`),
-			loc: loc,
+			pkg:      strings.Trim(i.Path.Value, `"`),
+			position: position,
 		})
 	}
 
@@ -87,15 +77,15 @@ func ordered(imports []importStmt) []importStmt {
 	// Compact
 	for i := range stdlibs {
 		if i > 0 {
-			stdlibs[i].loc.line = stdlibs[i-1].loc.line + 1
+			stdlibs[i].position.Line = stdlibs[i-1].position.Line + 1
 		}
 	}
 	if len(stdlibs) > 0 && len(others) > 0 {
-		others[0].loc.line = stdlibs[len(stdlibs)-1].loc.line + 2
+		others[0].position.Line = stdlibs[len(stdlibs)-1].position.Line + 2
 	}
 	for i := range others {
 		if i > 0 {
-			others[i].loc.line = others[i-1].loc.line + 1
+			others[i].position.Line = others[i-1].position.Line + 1
 		}
 	}
 
@@ -114,5 +104,5 @@ func compare(given, expected []importStmt) int {
 
 func report(out io.Writer, i importStmt) {
 	fmt.Fprintf(out, "%s:%d:%d: incorrectly sorted import package: %s\n",
-		i.loc.filename, i.loc.line, i.loc.col, i.pkg)
+		i.position.Filename, i.position.Line, i.position.Column, i.pkg)
 }

--- a/internal/rule/writeerror/rule.go
+++ b/internal/rule/writeerror/rule.go
@@ -102,10 +102,7 @@ func (v *FindMissingReturnsVisitor) Visit(n ast.Node) bool {
 
 		position := v.lastFound
 		position.Line++ // Report the next line
-		fmt.Fprintf(v.out, "%s:%d:%d: missing return statement after writeError call\n",
-			position.Filename,
-			position.Line,
-			position.Column)
+		fmt.Fprintf(v.out, "%s: missing return statement after writeError call\n", position)
 	}
 
 	v.state = 0 // Reset

--- a/internal/rule/writeerror/rule.go
+++ b/internal/rule/writeerror/rule.go
@@ -51,6 +51,7 @@ type FindMissingReturnsVisitor struct {
 	stateLevels map[int]int
 	level       int
 	state       int
+	lastFound   token.Position
 }
 
 // Visit implements the NodeVisitor interface.
@@ -85,6 +86,7 @@ func (v *FindMissingReturnsVisitor) Visit(n ast.Node) bool {
 				// fmt.Println("Debug: Found CallExpr")
 				v.state = 7
 				v.stateLevels[v.state] = v.level
+				v.lastFound = v.fset.Position(n.Pos())
 				return false
 			}
 		}
@@ -97,10 +99,13 @@ func (v *FindMissingReturnsVisitor) Visit(n ast.Node) bool {
 				return false
 			}
 		}
+
+		position := v.lastFound
+		position.Line++ // Report the next line
 		fmt.Fprintf(v.out, "%s:%d:%d: missing return statement after writeError call\n",
-			v.fset.Position(n.Pos()).Filename,
-			v.fset.Position(n.Pos()).Line,
-			v.fset.Position(n.Pos()).Column)
+			position.Filename,
+			position.Line,
+			position.Column)
 	}
 
 	v.state = 0 // Reset

--- a/internal/rule/writeerror/rule_test.go
+++ b/internal/rule/writeerror/rule_test.go
@@ -57,7 +57,7 @@ func Test_findMissingReturn(t *testing.T) {
 					fmt.Println("dummy text")
 				}
 				`,
-			expected: "main.go:14:6: missing return statement after writeError call\n",
+			expected: "main.go:13:7: missing return statement after writeError call\n",
 		},
 	}
 


### PR DESCRIPTION
The next node might be several token aways, which can mean several lines, which might be confusing to the developer.

Follow up from conversation over at https://github.com/betalo-sweden/caloris/pull/645#issuecomment-350568853